### PR TITLE
Guards versus Ruby

### DIFF
--- a/recipes/_master_war.rb
+++ b/recipes/_master_war.rb
@@ -28,14 +28,14 @@
 user node['jenkins']['master']['user'] do
   home node['jenkins']['master']['home']
   system node['jenkins']['master']['use_system_accounts'] # ~FC048
-  if { node['jenkins']['master']['create_user'] }
+  only_if { node['jenkins']['master']['create_user'] }
 end
 
 # Create the Jenkins group
 group node['jenkins']['master']['group'] do
   members node['jenkins']['master']['user']
   system node['jenkins']['master']['use_system_accounts'] # ~FC048
-  if { node['jenkins']['master']['create_user'] }
+  only_if { node['jenkins']['master']['create_user'] }
 end
 
 # Create the home directory


### PR DESCRIPTION
### Description

[Describe what this change achieves]
### Issues Resolved

[List any existing issues this PR resolves]
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

Rather than if which would occur during the execution phase, would be better to use a guard "only_if" which would occur during the compilation phase of the chef run.
For more info:
https://docs.chef.io/resource_common.html#guards
